### PR TITLE
Attribution powered by fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3174,9 +3174,9 @@
       }
     },
     "node_modules/esri-leaflet": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.8.tgz",
-      "integrity": "sha512-mLb4pRfDAbkG1YhuajD22erLXIAtrF1R32hmgmlJNI3t47n6KjTppCb8lViia0O7+GDORXFuJ9Lj9RkpsaKhSA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.13.tgz",
+      "integrity": "sha512-QP831w3vv2Hfy8aWUcUHJShSrg+EeIt5vxtTJZEHbgLzjS89QidEo1GrZ51u5KAIMuq8WPmNAurstU2AaCPS8g==",
       "dev": true,
       "dependencies": {
         "@terraformer/arcgis": "^2.1.0",
@@ -11134,9 +11134,9 @@
       }
     },
     "esri-leaflet": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.8.tgz",
-      "integrity": "sha512-mLb4pRfDAbkG1YhuajD22erLXIAtrF1R32hmgmlJNI3t47n6KjTppCb8lViia0O7+GDORXFuJ9Lj9RkpsaKhSA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.13.tgz",
+      "integrity": "sha512-QP831w3vv2Hfy8aWUcUHJShSrg+EeIt5vxtTJZEHbgLzjS89QidEo1GrZ51u5KAIMuq8WPmNAurstU2AaCPS8g==",
       "dev": true,
       "requires": {
         "@terraformer/arcgis": "^2.1.0",

--- a/src/StaticBasemapTileLayer.js
+++ b/src/StaticBasemapTileLayer.js
@@ -83,8 +83,15 @@ export var StaticBasemapTileLayer = TileLayer.extend({
     if (!this._map) return;
     fetchAttribution(this.options.style, this.options.token).then(attribution => {
       // Add attribution directly to map
-      this._map.attributionControl.addAttribution(`${POWERED_BY_ESRI_ATTRIBUTION_STRING} | ${attribution}`);
+      this.currentAttribution = `${POWERED_BY_ESRI_ATTRIBUTION_STRING} | ${attribution}`;
+      this._map.attributionControl.addAttribution(this.currentAttribution);
     });
+  },
+  _removeAttribution: function () {
+    if (this.currentAttribution) {
+      this._map.attributionControl.removeAttribution(this.currentAttribution);
+      this.currentAttribution = undefined;
+    }
   },
   _initPane: function () {
     if (this._map.getPane(this.options.pane)) return;

--- a/src/StaticBasemapTileLayer.js
+++ b/src/StaticBasemapTileLayer.js
@@ -14,7 +14,7 @@
  */
 import { TileLayer, setOptions } from 'leaflet';
 import { getStaticBasemapTilesUrl, fetchAttribution } from './Util';
-//import { Util } from 'esri-leaflet';
+// import { Util } from 'esri-leaflet';
 
 // In the future, get this from Esri Leaflet Util:
 const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
@@ -85,9 +85,6 @@ export var StaticBasemapTileLayer = TileLayer.extend({
       // Add attribution directly to map
       this._map.attributionControl.addAttribution(`${POWERED_BY_ESRI_ATTRIBUTION_STRING} | ${attribution}`);
     });
-  },
-  _removeAttribution: function () {
-    if (Util.removeEsriAttribution) Util.removeEsriAttribution(this._map);
   },
   _initPane: function () {
     if (this._map.getPane(this.options.pane)) return;

--- a/src/StaticBasemapTileLayer.js
+++ b/src/StaticBasemapTileLayer.js
@@ -16,6 +16,9 @@ import { TileLayer, setOptions } from 'leaflet';
 import { getStaticBasemapTilesUrl, fetchAttribution } from './Util';
 import { Util } from 'esri-leaflet';
 
+// In the future, get this from Esri Leaflet Util:
+const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
+
 export var StaticBasemapTileLayer = TileLayer.extend({
   initialize: function (style, options) {
     if (options) {
@@ -78,10 +81,9 @@ export var StaticBasemapTileLayer = TileLayer.extend({
   },
   _setupAttribution: function () {
     if (!this._map) return;
-    Util.setEsriAttribution(this._map);
     fetchAttribution(this.options.style, this.options.token).then(attribution => {
       // Add attribution directly to map
-      this._map.attributionControl.addAttribution(attribution);
+      this._map.attributionControl.addAttribution(`${POWERED_BY_ESRI_ATTRIBUTION_STRING} | ${attribution}`);
     });
   },
   _removeAttribution: function () {

--- a/src/StaticBasemapTileLayer.js
+++ b/src/StaticBasemapTileLayer.js
@@ -14,7 +14,7 @@
  */
 import { TileLayer, setOptions } from 'leaflet';
 import { getStaticBasemapTilesUrl, fetchAttribution } from './Util';
-import { Util } from 'esri-leaflet';
+//import { Util } from 'esri-leaflet';
 
 // In the future, get this from Esri Leaflet Util:
 const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';


### PR DESCRIPTION
Associated issue: #2

Removes call to `Util.setEsriAttribution` and adds the `Powered by Esri` label.